### PR TITLE
fix background draw

### DIFF
--- a/controls.py
+++ b/controls.py
@@ -30,7 +30,6 @@ def update(screen, maincharacter, enemys, bullets):
         bullet.draw_bullet()
     maincharacter.output()
     enemys.draw(screen)
-    #pygame.display.flip()
 
 
 def update_bullets(screen, enemys, bullets):

--- a/controls.py
+++ b/controls.py
@@ -26,13 +26,11 @@ def events(screen, maincharacter, bullets):
 
 
 def update(screen, maincharacter, enemys, bullets):
-    bg = pygame.image.load("images/bg.png")
-    screen.fill(0)
     for bullet in bullets.sprites():
         bullet.draw_bullet()
     maincharacter.output()
     enemys.draw(screen)
-    pygame.display.flip()
+    #pygame.display.flip()
 
 
 def update_bullets(screen, enemys, bullets):

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from stats import Stats
 
 def start_game():
     pygame.init()
-    screen = pygame.display.set_mode((1000, 900))
+    screen = pygame.display.set_mode((1000, 672))
     pygame.display.set_caption("WAY2DIE")
 
     
@@ -17,18 +17,19 @@ def start_game():
 
     controls.create_army(screen, enemys)
     bg = pygame.image.load("images/bg.png")
-    screen.blit(bg, (0, 0))
 
     stats = Stats()
     flag = True
     while flag:
+        screen.blit(bg, (0, 0))
         controls.events(screen, maincharacter, bullets)
         maincharacter.output()
-        pygame.display.flip()
         maincharacter.moving(screen)
 
         controls.update(screen, maincharacter, enemys, bullets)
         controls.update_bullets(screen, enemys,bullets)
         controls.update_enemys(stats, screen, maincharacter, enemys, bullets)
+        pygame.display.flip()
+        screen.fill(0)
 
 start_game()

--- a/main_character.py
+++ b/main_character.py
@@ -21,7 +21,7 @@ class MainCharacter():
             self.rect.centerx += 1
         if self.move_left and self.rect.left > 0:
             self.rect.centerx -= 1
-        screen.fill(0)
+
 
     def create_maincharacter_again(self):
         self.center = self.screen_rect.centerx


### PR DESCRIPTION
1. Отрисовку фона нужно делать в начале цикла screen.blit(bg, (0, 0))
2. Итоговую отрисовку в конце цикла - pygame.display.flip()
3. Лишний screen.fill(0) посреди цикла стирал фон
4. Лишние отрисовки были из-за многократного вызова pygame.display.flip() посреди цикла